### PR TITLE
Add e2e tests and fix example workflow

### DIFF
--- a/examples/extraction-workflow.json
+++ b/examples/extraction-workflow.json
@@ -1,68 +1,44 @@
 {
-  "name": "Entity Extraction Pipeline",
-  "description": "Extract entities and relations from text using the configured extraction backend.",
-  "nodes": [
+  "name": "Entity Extraction",
+  "description": "Extract named entities from text using an LLM.",
+  "input_node": {
+    "id": "input",
+    "type": "Input",
+    "params": {
+      "fields": {
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "description": "The text to extract entities from"
+        }
+      }
+    }
+  },
+  "output_node": {
+    "id": "output",
+    "type": "Output",
+    "params": {
+      "fields": {
+        "entities": {
+          "type": "string",
+          "title": "Entities",
+          "description": "Extracted entities as structured text"
+        }
+      }
+    }
+  },
+  "inner_nodes": [
     {
-      "id": "extraction",
-      "type": "Extraction",
+      "id": "llm",
+      "type": "LLM",
       "params": {
-        "backend": "gliner2",
-        "confidence_threshold": "0.5"
-      },
-      "position": { "x": 400, "y": 200 }
-    }
-  ],
-  "edges": [],
-  "input_edges": [
-    {
-      "input_key": "text",
-      "target_id": "extraction",
-      "target_key": "text"
-    },
-    {
-      "input_key": "extraction_schema",
-      "target_id": "extraction",
-      "target_key": "extraction_schema"
-    }
-  ],
-  "output_edges": [
-    {
-      "source_id": "extraction",
-      "source_key": "result",
-      "output_key": "result"
-    }
-  ],
-  "inputs": [
-    {
-      "name": "text",
-      "type": "LONG_TEXT",
-      "display_name": "Text Content",
-      "description": "The text to extract entities and relations from"
-    },
-    {
-      "name": "extraction_schema",
-      "type": "JSON",
-      "display_name": "Extraction Schema",
-      "description": "JSON schema defining entity types and relation types to extract",
-      "default": {
-        "entity_types": [
-          { "type_id": "person" },
-          { "type_id": "organization" },
-          { "type_id": "location" }
-        ],
-        "relation_types": [
-          { "type_id": "works_at", "description": "Person works at organization" },
-          { "type_id": "located_in", "description": "Entity is located in a place" }
-        ]
+        "model": "gpt-4o-mini",
+        "system_prompt": "Extract all named entities (people, organizations, locations) from the text. Return them as a structured list grouped by type."
       }
     }
   ],
-  "outputs": [
-    {
-      "name": "result",
-      "type": "JSON",
-      "display_name": "Extraction Result",
-      "description": "Extracted entities and relations with confidence scores (V2 ExtractionResult)"
-    }
+  "edges": [
+    { "source_id": "input", "source_key": "text", "target_id": "llm", "target_key": "prompt" },
+    { "source_id": "llm", "source_key": "response", "target_id": "output", "target_key": "entities" }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "vitest run tests/integration"
+    "test:integration": "vitest run tests/integration",
+    "test:e2e": "bash scripts/e2e.sh"
   },
   "files": [
     "dist"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# End-to-end smoke tests for the ace CLI.
+# Requires: OPENAI_API_KEY (or source ../aceteam/.env)
+set -euo pipefail
+
+ACE="node $(dirname "$0")/../dist/index.js"
+PASS=0
+FAIL=0
+FAILURES=()
+
+# ── Helpers ──────────────────────────────────────────────────
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+dim()   { printf '\033[2m%s\033[0m\n' "$*"; }
+
+run_test() {
+  local name="$1"; shift
+  printf "  %-40s " "$name"
+  if output=$("$@" 2>&1); then
+    green "✓"
+    PASS=$((PASS + 1))
+  else
+    red "✗"
+    FAILURES+=("$name")
+    dim "    $output" | head -5
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Check output contains a string
+assert_contains() {
+  local name="$1" expected="$2"; shift 2
+  printf "  %-40s " "$name"
+  if output=$("$@" 2>&1) && echo "$output" | grep -qF -- "$expected"; then
+    green "✓"
+    PASS=$((PASS + 1))
+  else
+    red "✗"
+    FAILURES+=("$name")
+    dim "    expected to contain: $expected"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Check command fails (non-zero exit)
+assert_fails() {
+  local name="$1"; shift
+  printf "  %-40s " "$name"
+  if output=$("$@" 2>&1); then
+    red "✗ (expected failure, got success)"
+    FAILURES+=("$name")
+    FAIL=$((FAIL + 1))
+  else
+    green "✓"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ── Load API key ─────────────────────────────────────────────
+
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  ENV_FILE="$(dirname "$0")/../../aceteam/.env"
+  if [ -f "$ENV_FILE" ]; then
+    OPENAI_API_KEY=$(grep '^OPENAI_API_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+    export OPENAI_API_KEY
+  fi
+fi
+
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  red "ERROR: OPENAI_API_KEY not set and ../aceteam/.env not found"
+  exit 1
+fi
+
+# ── Build ────────────────────────────────────────────────────
+
+echo ""
+echo "Building..."
+(cd "$(dirname "$0")/.." && pnpm build --silent 2>&1) || { red "Build failed"; exit 1; }
+echo ""
+
+# ── CLI basics ───────────────────────────────────────────────
+
+echo "CLI basics"
+assert_contains "ace --version"          "0."            $ACE --version
+assert_contains "ace --help shows run"   "run"           $ACE --help
+assert_contains "ace --help shows login" "login"         $ACE --help
+assert_contains "ace run --help"         "--input"       $ACE run --help
+assert_contains "ace login --help"       "--api-key"     $ACE login --help
+assert_contains "ace workflow --help"    "validate"      $ACE workflow --help
+echo ""
+
+# ── Task listing ─────────────────────────────────────────────
+
+echo "Task listing"
+assert_contains "ace run --list"         "summarize"     $ACE run --list
+assert_contains "ace run --info"         "Summarize"     $ACE run --info summarize
+echo ""
+
+# ── Task execution (LLM) ────────────────────────────────────
+
+echo "Task execution"
+assert_contains "ace run summarize (pipe)" "Summary" \
+  bash -c "echo 'The Eiffel Tower is a wrought-iron lattice tower in Paris, France.' | $ACE run summarize"
+
+assert_contains "ace run summarize (inline)" "Summary" \
+  $ACE run summarize "The Eiffel Tower is a wrought-iron lattice tower in Paris, France."
+echo ""
+
+# ── Workflow validation ──────────────────────────────────────
+
+echo "Workflow validation"
+assert_contains "validate example workflow" "Valid workflow" \
+  $ACE workflow validate examples/extraction-workflow.json
+
+# Invalid JSON
+TMPFILE=$(mktemp /tmp/ace-e2e-XXXXXX.json)
+echo "not json" > "$TMPFILE"
+assert_fails "reject invalid JSON" \
+  $ACE workflow validate "$TMPFILE"
+
+# Valid JSON, bad schema
+echo '{"foo": "bar"}' > "$TMPFILE"
+assert_fails "reject bad schema" \
+  $ACE workflow validate "$TMPFILE"
+rm -f "$TMPFILE"
+echo ""
+
+# ── Workflow execution (LLM) ────────────────────────────────
+
+echo "Workflow execution"
+assert_contains "ace run extraction workflow" "entities" \
+  $ACE run examples/extraction-workflow.json \
+    --input "text=Marie Curie worked at the University of Paris in France."
+echo ""
+
+# ── Node listing ─────────────────────────────────────────────
+
+echo "Node listing"
+assert_contains "ace workflow list-nodes" "LLM" \
+  $ACE workflow list-nodes
+
+assert_contains "ace workflow list-templates" "hello-llm" \
+  $ACE workflow list-templates
+echo ""
+
+# ── Error handling ───────────────────────────────────────────
+
+echo "Error handling"
+assert_fails "reject nonexistent task" \
+  $ACE run nonexistent-task-xyz "hello"
+
+assert_fails "reject nonexistent workflow file" \
+  $ACE run /tmp/does-not-exist.json --input text=hello
+echo ""
+
+# ── Results ──────────────────────────────────────────────────
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [ "$FAIL" -eq 0 ]; then
+  green "All $PASS tests passed"
+else
+  red "$FAIL failed, $PASS passed"
+  echo ""
+  for f in "${FAILURES[@]}"; do
+    red "  FAIL: $f"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Context

### Why
We've been running manual smoke tests after every change — slow and error-prone. The only example workflow (`extraction-workflow.json`) was broken: it used a stale v1 schema with a non-existent `Extraction` node type, so `ace run examples/extraction-workflow.json` always failed.

### What
Automated e2e test script (`pnpm test:e2e`) and a working example workflow.

### How
- `scripts/e2e.sh` — 18 tests that build the CLI and exercise it end-to-end against OpenAI (help, listing, task execution, workflow validation, workflow execution, error handling)
- `examples/extraction-workflow.json` — Rewritten to v2 schema using an `LLM` node with a system prompt for entity extraction

## Summary

| Component | Change |
|-----------|--------|
| `scripts/e2e.sh` | New — 18 automated smoke tests covering all CLI surface area |
| `package.json` | Added `test:e2e` script |
| `examples/extraction-workflow.json` | Rewritten from broken v1/Extraction to working v2/LLM |

## Test plan

- [x] `pnpm test` — 154 unit tests pass
- [x] `pnpm test:e2e` — 18/18 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)