### PR TITLE
feat: ace init starts SafeClaw proxy for safety + cost tracking

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -17,7 +17,13 @@ import {
   installAceteamNodes,
   isAceteamNodesInstalled,
 } from "../utils/python.js";
+import { confirm } from "@inquirer/prompts";
 import { detectProvider, providerLabel } from "../utils/provider-detect.js";
+import {
+  detectContainerRuntime,
+  isProxyRunning,
+  startProxy,
+} from "../utils/proxy.js";
 import { DEMOS } from "../demos/index.js";
 import * as output from "../utils/output.js";
 
@@ -238,6 +244,56 @@ export const initCommand = new Command("init")
           `  ${chalk.cyan("Tier 3 — AceTeam Platform")}` +
           "\n" +
           `  ${chalk.dim("ace login           # Full node support + remote execution")}`
+      );
+    }
+
+    // Step 6: SafeClaw proxy
+    console.log(chalk.bold("\n6. SafeClaw Proxy"));
+
+    const containerRuntime = detectContainerRuntime();
+    if (containerRuntime) {
+      const alreadyRunning = isProxyRunning();
+      if (alreadyRunning) {
+        ora().succeed("SafeClaw proxy already running on port 8899");
+        config.proxy_enabled = true;
+        config.proxy_url = "http://localhost:8899";
+        config.proxy_container = "safeclaw-proxy";
+        saveConfig(config);
+      } else {
+        const startSafety = await confirm({
+          message:
+            "Start SafeClaw proxy for safety + cost tracking? (recommended)",
+          default: true,
+        });
+
+        if (startSafety) {
+          const spinner = ora("Starting SafeClaw proxy...").start();
+          const started = startProxy(containerRuntime);
+          if (started) {
+            spinner.succeed(
+              "SafeClaw proxy running — dashboard at http://localhost:8899/aep/"
+            );
+            config.proxy_enabled = true;
+            config.proxy_url = "http://localhost:8899";
+            config.proxy_container = "safeclaw-proxy";
+            saveConfig(config);
+          } else {
+            spinner.fail(
+              "Could not start proxy container. You can start it manually later with:"
+            );
+            console.log(
+              chalk.dim(
+                `  ${containerRuntime} run -d --name safeclaw-proxy -p 8899:8899 ghcr.io/aceteam-ai/aep-proxy:latest`
+              )
+            );
+          }
+        } else {
+          output.info("Skipped — run ace init again to enable later");
+        }
+      }
+    } else {
+      output.info(
+        "Install Podman or Docker to enable SafeClaw safety proxy"
       );
     }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -15,6 +15,9 @@ export interface AceConfig {
   patterns_dir?: string;
   api_keys?: { openai?: string; anthropic?: string };
   user_email?: string;
+  proxy_enabled?: boolean;
+  proxy_url?: string;
+  proxy_container?: string;
 }
 
 export function getConfigPath(): string {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,4 +1,4 @@
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 export interface ProxyConfig {
   enabled: boolean;
@@ -72,7 +72,7 @@ export function startProxy(
     // Poll until proxy is ready (up to ~15 s)
     for (let i = 0; i < 30; i++) {
       if (isProxyRunning(port)) return true;
-      execSync("sleep 0.5", { stdio: "ignore" });
+      execFileSync("sleep", ["0.5"], { stdio: "ignore" });
     }
     return false;
   } catch {

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,93 @@
+import { execFileSync, execSync } from "node:child_process";
+
+export interface ProxyConfig {
+  enabled: boolean;
+  url: string;
+  container_name: string;
+  container_runtime: "podman" | "docker" | null;
+}
+
+/**
+ * Detect the first available container runtime (Podman preferred over Docker).
+ */
+export function detectContainerRuntime(): "podman" | "docker" | null {
+  for (const cmd of ["podman", "docker"] as const) {
+    try {
+      execFileSync("which", [cmd], { stdio: "ignore" });
+      return cmd;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check whether the SafeClaw proxy is accepting connections on the given port.
+ */
+export function isProxyRunning(port: number = 8899): boolean {
+  try {
+    execFileSync(
+      "curl",
+      ["-sf", `http://localhost:${port}/aep/api/state`],
+      { stdio: "ignore", timeout: 2000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pull and start the SafeClaw proxy container.
+ * Forwards OPENAI_API_KEY and ANTHROPIC_API_KEY from the current environment.
+ * Returns true if the proxy is reachable within ~15 seconds.
+ */
+export function startProxy(
+  runtime: "podman" | "docker",
+  port: number = 8899
+): boolean {
+  const image = "ghcr.io/aceteam-ai/aep-proxy:latest";
+  const name = "safeclaw-proxy";
+
+  try {
+    // Remove any existing stopped container with the same name
+    try {
+      execFileSync(runtime, ["rm", "-f", name], { stdio: "ignore" });
+    } catch {
+      // Container may not exist — fine
+    }
+
+    const args = ["run", "-d", "--name", name, "-p", `${port}:${port}`];
+    for (const key of ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]) {
+      const value = process.env[key];
+      if (value) {
+        args.push("-e", `${key}=${value}`);
+      }
+    }
+    args.push(image);
+
+    execFileSync(runtime, args, { stdio: "pipe" });
+
+    // Poll until proxy is ready (up to ~15 s)
+    for (let i = 0; i < 30; i++) {
+      if (isProxyRunning(port)) return true;
+      execSync("sleep 0.5", { stdio: "ignore" });
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stop and remove the SafeClaw proxy container.
+ */
+export function stopProxy(runtime: "podman" | "docker"): void {
+  try {
+    execFileSync(runtime, ["stop", "safeclaw-proxy"], { stdio: "ignore" });
+    execFileSync(runtime, ["rm", "safeclaw-proxy"], { stdio: "ignore" });
+  } catch {
+    // Container may not exist — that's fine
+  }
+}


### PR DESCRIPTION
## Context

**Why:** Every LLM call made through the Ace CLI today goes directly to OpenAI/Anthropic with no visibility into cost or safety. As AceTeam ships the SafeClaw proxy as its primary safety product, ace needs to be the first distribution channel — users who run \`ace init\` should get safety enforcement and cost tracking by default, not as an afterthought.

**What:** A new step in \`ace init\` that detects a local container runtime (Podman or Docker), asks the user if they want to start the SafeClaw proxy (default: yes), pulls \`ghcr.io/aceteam-ai/aep-proxy:latest\`, and stores proxy config in \`~/.ace/config.yaml\`.

**How:** A new \`src/utils/proxy.ts\` utility encapsulates container runtime detection, proxy health checking (via \`curl\` to \`/aep/api/state\`), and container start/stop. The init wizard calls these functions in a new Step 6 after the LLM provider detection step. All container operations use \`execFileSync\` with explicit argument arrays (no shell interpolation of user input). API keys are forwarded from the environment directly into the container.

Example flow:
\`\`\`
6. SafeClaw Proxy
✔  SafeClaw proxy running — dashboard at http://localhost:8899/aep/
\`\`\`

## Summary

| Component | Change | Why |
|---|---|---|
| \`src/utils/proxy.ts\` | New utility | Encapsulates container runtime detection, proxy health check, start/stop |
| \`src/commands/init.ts\` | Step 6 added | Prompts user to start proxy; updates config on success |
| \`src/utils/config.ts\` | 3 new fields | \`proxy_enabled\`, \`proxy_url\`, \`proxy_container\` typed on \`AceConfig\` |

Key decisions:
- **Podman-first**: Podman is checked before Docker since it is rootless by default — safer for a developer tool
- **Graceful skip**: Missing container runtime prints an info message, not an error — init still completes
- **Already-running detection**: If the proxy is already up (e.g., from a previous init), skip the prompt entirely
- **execFileSync with arrays**: No shell string interpolation — all args passed as array elements to prevent injection

## Test plan

- [ ] `pnpm build` passes (verified)
- [ ] `pnpm lint` (tsc --noEmit) passes with zero errors (verified)
- [ ] Manual: `ace init` with Docker installed → proxy step appears, answers Y → container starts, config written
- [ ] Manual: `ace init` with proxy already on port 8899 → skips prompt, shows "already running"
- [ ] Manual: `ace init` with no container runtime → shows info message, init completes normally
- [ ] Manual: `ace init`, answer N to proxy prompt → config not written, init completes

## Related

- SafeClaw proxy: https://github.com/aceteam-ai/safeclaw
- AEP SDK: https://pypi.org/project/aceteam-aep/

---
*Generated by Claude*